### PR TITLE
fix(users): Add error handling to getFullProfile

### DIFF
--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException, InternalServerErrorException, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { User } from '@prisma/client';
 import { UpdateUserDto } from '../common/dtos/update-user.dto';
@@ -7,6 +7,7 @@ import Decimal from 'decimal.js';
 
 @Injectable()
 export class UsersService {
+  private readonly logger = new Logger(UsersService.name);
   constructor(private prisma: PrismaService) {}
 
   // =================================================================
@@ -59,54 +60,62 @@ export class UsersService {
   async getFullProfile(userId: string) {
     if (!userId) throw new BadRequestException('userId missing');
 
-    const userWithCounts = await this.prisma.user.findUnique({
-      where: { id: userId },
-      include: {
-        deFiProfile: true,
-        _count: { select: { referrals: true, completedMissions: true } },
-      },
-    });
-
-    if (!userWithCounts) {
-      throw new NotFoundException('Pengguna tidak ditemukan.');
-    }
-
-    let rank = 0;
-    const pointsLeaderboard = await this.prisma.leaderboard.findUnique({
-      where: { name: 'points' },
-      select: { id: true },
-    });
-
-    if (pointsLeaderboard) {
-      const entry = await this.prisma.leaderboardEntry.findUnique({
-        where: { leaderboardId_userId: { leaderboardId: pointsLeaderboard.id, userId } },
-        select: { rank: true },
+    try {
+      const userWithCounts = await this.prisma.user.findUnique({
+        where: { id: userId },
+        include: {
+          deFiProfile: true,
+          _count: { select: { referrals: true, completedMissions: true } },
+        },
       });
-      if (entry) rank = entry.rank;
-    }
 
-    return {
-      username: userWithCounts.twitterHandle || `User_${userWithCounts.walletAddress.slice(-4)}`,
-      walletAddress: userWithCounts.walletAddress,
-      points: userWithCounts.points,
-      rank,
-      referralCode: userWithCounts.referralCode,
-      totalReferrals: userWithCounts._count.referrals,
-      missionsCompleted: userWithCounts._count.completedMissions,
-      socials: {
-        twitter: userWithCounts.twitterHandle,
-        telegram: userWithCounts.telegramHandle,
-        discord: userWithCounts.discordId,
-        line: userWithCounts.lineId,
-      },
-      defiStats: userWithCounts.deFiProfile
-        ? {
-            totalSwapVolume: new Decimal(userWithCounts.deFiProfile.totalSwapVolume).toNumber(),
-            totalStakingVolume: new Decimal(userWithCounts.deFiProfile.totalStakingVolume).toNumber(),
-            totalLendSupplyVolume: new Decimal(userWithCounts.deFiProfile.totalLendSupplyVolume).toNumber(),
-          }
-        : null,
-    };
+      if (!userWithCounts) {
+        throw new NotFoundException('Pengguna tidak ditemukan.');
+      }
+
+      let rank = 0;
+      const pointsLeaderboard = await this.prisma.leaderboard.findUnique({
+        where: { name: 'points' },
+        select: { id: true },
+      });
+
+      if (pointsLeaderboard) {
+        const entry = await this.prisma.leaderboardEntry.findUnique({
+          where: { leaderboardId_userId: { leaderboardId: pointsLeaderboard.id, userId } },
+          select: { rank: true },
+        });
+        if (entry) rank = entry.rank;
+      }
+
+      return {
+        username: userWithCounts.twitterHandle || `User_${userWithCounts.walletAddress.slice(-4)}`,
+        walletAddress: userWithCounts.walletAddress,
+        points: userWithCounts.points,
+        rank,
+        referralCode: userWithCounts.referralCode,
+        totalReferrals: userWithCounts._count.referrals,
+        missionsCompleted: userWithCounts._count.completedMissions,
+        socials: {
+          twitter: userWithCounts.twitterHandle,
+          telegram: userWithCounts.telegramHandle,
+          discord: userWithCounts.discordId,
+          line: userWithCounts.lineId,
+        },
+        defiStats: userWithCounts.deFiProfile
+          ? {
+              totalSwapVolume: new Decimal(userWithCounts.deFiProfile.totalSwapVolume).toNumber(),
+              totalStakingVolume: new Decimal(userWithCounts.deFiProfile.totalStakingVolume).toNumber(),
+              totalLendSupplyVolume: new Decimal(userWithCounts.deFiProfile.totalLendSupplyVolume).toNumber(),
+            }
+          : null,
+      };
+    } catch (error) {
+      this.logger.error(`Failed to get full profile for userId ${userId}:`, error.stack);
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      throw new InternalServerErrorException('Could not retrieve user profile.');
+    }
   }
 
   // =================================================================


### PR DESCRIPTION
Wrapped the database queries and logic within the `getFullProfile` method in `users.service.ts` with a try-catch block.

This prevents unhandled exceptions, particularly from Prisma, from crashing the server process, which was causing `net::ERR_CONNECTION_RESET` errors on the client.

Errors are now caught, logged, and re-thrown as a standard `InternalServerErrorException`, ensuring the server responds with a proper 500 error instead of crashing.